### PR TITLE
Create organizer.yaml to test Github Organization Manager

### DIFF
--- a/organizer.yaml
+++ b/organizer.yaml
@@ -1,0 +1,12 @@
+teams:
+  w3dt-stewards:
+    members:
+      - aschmahmann
+      - biglep
+      - stebalien
+      - warpfork
+      
+repositories:
+  default:
+    teams:
+      w3dt-stewards: Admin


### PR DESCRIPTION
This is following: https://organizer.gitconsensus.com/#/?id=teams and https://organizer.gitconsensus.com/#/?id=assign-teams-and-permissions

It's being used to see if we can bootstrap team population using Github Organization Manager and to see if that team gets assigned to all repositories.